### PR TITLE
Make SimpleCommand::Errors consistent with ActiveModel::Errors

### DIFF
--- a/lib/simple_command/errors.rb
+++ b/lib/simple_command/errors.rb
@@ -13,5 +13,11 @@ module SimpleCommand
         values.each { |value| add key, value }
       end
     end
+
+    def each
+      each_key do |field|
+        self[field].each { |message| yield field, message }
+      end
+    end
   end
 end

--- a/spec/simple_command/errors_spec.rb
+++ b/spec/simple_command/errors_spec.rb
@@ -35,4 +35,24 @@ describe SimpleCommand::Errors do
       expect(errors[:another_error]).to eq(errors_list[:another_error])
     end
   end
+
+  describe '#each' do
+    let(:errors_list) do
+      {
+        email: ['taken'],
+        password: ['blank', 'too short']
+      }
+    end
+
+    before { errors.add_multiple_errors(errors_list) }
+
+    it 'yields each message for the same key independently' do
+      expect { |b| errors.each(&b) }.to yield_control.exactly(3).times
+      expect { |b| errors.each(&b) }.to yield_successive_args(
+        [:email, 'taken'],
+        [:password, 'blank'],
+        [:password, 'too short']
+      )
+    end
+  end
 end


### PR DESCRIPTION
This pull request changes the way errors are iterated with each. Instead
of yielding `:field, ['error1', 'error2']` pairs in each iteration,
yield `:field, 'error1'` then `:field, 'error2'`.

This makes it consistent with the way ActiveModel::Errors behave and
allows for easier integration with form objects.