### PR TITLE
Fix inconsistent arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Make the spec file `spec/commands/authenticate_user_spec.rb` like:
 
 ```ruby
 describe AuthenticateUser do
-  subject(:context) { described_class.call(user, password) }
+  subject(:context) { described_class.call(username, password) }
 
   describe '.call' do
     context 'when the context is successful' do


### PR DESCRIPTION
The readme currently has inconsistent arguments in the RSpec example.