### PR TITLE
Allow using ActiveModel::Validation errors

### DIFF
--- a/lib/simple_command.rb
+++ b/lib/simple_command.rb
@@ -33,6 +33,8 @@ module SimpleCommand
   end
 
   def errors
+    return super if defined?(super)
+
     @errors ||= Errors.new
   end
 


### PR DESCRIPTION
Now if you use `simple_command` in Rails you can include `ActiveModel::Validations` into class and use it's `errors` functionality which is match wider.

PS Could you release a new ruby gem? Because the current one is 4 years old.