### PR TITLE
Allows passing a block to be executed when command succeeded

### DIFF
--- a/lib/simple_command.rb
+++ b/lib/simple_command.rb
@@ -5,8 +5,8 @@ module SimpleCommand
   attr_reader :result
 
   module ClassMethods
-    def call(*args)
-      new(*args).call
+    def call(*args, &block)
+      new(*args).call(&block)
     end
   end
 
@@ -19,6 +19,8 @@ module SimpleCommand
 
     @called = true
     @result = super
+
+    yield(self) if success? && block_given?
 
     self
   end


### PR DESCRIPTION
Hi guys!

This small change is aimed to simplify controller logic, moving from something like this:
```ruby
  def create
    command = AuthenticateUser.call(session_params[:email], session_params[:password])

    if command.success?
      redirect_to root_path
    else
      render :new
    end
  end
```
To this
```ruby
  def create
    AuthenticateUser.call(session_params[:email], session_params[:password]) do
      # return keyword is key here to avoid `duplicate render/redirect error`
      return redirect_to root_path      
    end

    # executed only when command fails
    render :new
  end
```

**The `block` passed to `Command.call` will be executed only when command  is success**