### PR TITLE
Add test coverage for Errors#to_json

### DIFF
--- a/spec/simple_command/errors_spec.rb
+++ b/spec/simple_command/errors_spec.rb
@@ -66,7 +66,18 @@ describe SimpleCommand::Errors do
     it "returrns the full messages array" do
       expect(errors.full_messages).to eq ["Attr1 has an error", "Attr2 has an error", "Attr2 has two errors"]
     end
-
   end
 
+  describe "#to_json" do
+    it "groups errors by key values" do
+      errors.add :attr1, 'has an error'
+      errors.add :attr2, 'has an error'
+      errors.add :attr2, 'has two errors'
+
+      expect(JSON.parse(errors.to_json)).to eq(
+        "attr1" => ["has an error"],
+        "attr2" => ["has an error", "has two errors"]
+      )
+    end
+  end
 end


### PR DESCRIPTION
I looked into Issue #24 to determine why the Errors object was behaving differently from "ActiveSupport::Errors".

So far I've failed to find any differences, but I added some basic test coverage to "to_json" while testing.

Feel free to merge this, or close this ticket.