### PR TITLE
Allow Errors#add_multiple_errors to copy another Errors object

### DIFF
--- a/lib/simple_command.rb
+++ b/lib/simple_command.rb
@@ -1,4 +1,5 @@
 require 'simple_command/version'
+require 'simple_command/utils'
 require 'simple_command/errors'
 
 module SimpleCommand

--- a/lib/simple_command/errors.rb
+++ b/lib/simple_command/errors.rb
@@ -10,7 +10,7 @@ module SimpleCommand
 
     def add_multiple_errors(errors_hash)
       errors_hash.each do |key, values|
-        values.each { |value| add key, value }
+        SimpleCommand::Utils.array_wrap(values).each { |value| add key, value }
       end
     end
 

--- a/lib/simple_command/utils.rb
+++ b/lib/simple_command/utils.rb
@@ -1,0 +1,14 @@
+module SimpleCommand
+  module Utils
+    # Borrowed from active_support/core_ext/array/wrap
+    def self.array_wrap(object)
+      if object.nil?
+        []
+      elsif object.respond_to?(:to_ary)
+        object.to_ary || [object]
+      else
+        [object]
+      end
+    end
+  end
+end

--- a/spec/simple_command/errors_spec.rb
+++ b/spec/simple_command/errors_spec.rb
@@ -19,20 +19,32 @@ describe SimpleCommand::Errors do
   end
 
   describe '#add_multiple_errors' do
-    let(:errors_list) do
-      {
+    it 'populates itself with the added errors' do
+      errors_list = {
         some_error: ['some error description'],
         another_error: ['another error description']
       }
-    end
 
-    before do
       errors.add_multiple_errors errors_list
-    end
 
-    it 'populates itself with the added errors' do
       expect(errors[:some_error]).to eq(errors_list[:some_error])
       expect(errors[:another_error]).to eq(errors_list[:another_error])
+    end
+
+    it 'copies errors from another SimpleCommand::Errors object' do
+      command_errors = SimpleCommand::Errors.new
+      command_errors.add :some_error, "was found"
+      command_errors.add :some_error, "happened again"
+
+      errors.add_multiple_errors command_errors
+
+      expect(errors[:some_error]).to eq(["was found", "happened again"])
+    end
+
+    it "ignores nil values" do
+      errors.add_multiple_errors({:foo => nil})
+
+      expect(errors[:foo]).to eq nil
     end
   end
 


### PR DESCRIPTION
I had a look at Issue #23 and I think I've found the problem.

It looks like the vdaubry was attempting to use SimpleCommand::Errors#add_mutliple_errors to copy values over from another SimpleCommand::Errors object.

Attempting to do the same thing resulted in the same error he reported on my end.

In the past I've used Array.wrap from ActiveSupport to fix this type of issue, but as we don't have ActiveSupport as a dependency (and probably shouldn't) I ported the logic over.

Added tests to verify the fix.