### PR TITLE
handle keyword arguments without warning in Ruby 2.7 & 3

### DIFF
--- a/lib/simple_command.rb
+++ b/lib/simple_command.rb
@@ -5,8 +5,8 @@ module SimpleCommand
   attr_reader :result
 
   module ClassMethods
-    def call(*args)
-      new(*args).call
+    def call(*args, **kwargs)
+      new(*args, **kwargs).call
     end
   end
 


### PR DESCRIPTION
Tested locally in ruby 2.5, 2.6 and 2.7