### PR TITLE
Update gemspec ruby version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["2.7", "3.0", "3.1", ruby-head, jruby-9.3, jruby-head]
+        ruby: ["2.6", "2.7", "3.0", "3.1", ruby-head, jruby-9.3, jruby-head]
 
     steps:
     - uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A simple, standardized way to build and use _Service Objects_ (aka _Commands_) i
 
 ## Requirements
 
-* Ruby 2.7+
+* Ruby 2.6+
 
 ## Installation
 

--- a/simple_command.gemspec
+++ b/simple_command.gemspec
@@ -4,7 +4,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'simple_command/version'
 
 Gem::Specification.new do |s|
-  s.required_ruby_version = '>= 2.0'
+  s.required_ruby_version = '>= 2.6'
   s.name          = 'simple_command'
   s.version       = SimpleCommand::VERSION
   s.authors       = ['Andrea Pavoni']


### PR DESCRIPTION
The past Ruby versions are not supported anymore.

Please note that Ruby 2.6 has been reintroduced because it's still needed for JRuby 9.3.